### PR TITLE
Add hallucination evaluation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ llm-qa-evaluator/
 - **Framework de Testing**
   - Gestión de prompts con utilidades simples en Python.
   - Automatización de la validación de outputs mediante `pytest`.
+  - Evaluación de alucinaciones mediante el módulo `llmqa.hallucination`.
 - **Casos de Estudio de Ingeniería de Prompts**
   - Documentación de iteraciones y hallazgos.
 - **Documentación Profesional**

--- a/llmqa/__init__.py
+++ b/llmqa/__init__.py
@@ -1,0 +1,9 @@
+from .evaluator import LLMEvaluator, PromptResult
+from .hallucination import HallucinationEvaluator, HallucinationResult
+
+__all__ = [
+    "LLMEvaluator",
+    "PromptResult",
+    "HallucinationEvaluator",
+    "HallucinationResult",
+]

--- a/llmqa/hallucination.py
+++ b/llmqa/hallucination.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+
+@dataclass
+class HallucinationResult:
+    prompt: str
+    response: str
+    score: Dict[str, float]
+
+
+class HallucinationEvaluator:
+    """Heurística simple para detección de alucinaciones."""
+
+    def __init__(self, reference_facts: List[str]):
+        # Lista de hechos conocidos contra los que validar las respuestas
+        self.reference_facts = [f.lower() for f in reference_facts]
+
+    def evaluate(self, prompt: str, response: str) -> HallucinationResult:
+        lower_resp = response.lower()
+        matches = [fact for fact in self.reference_facts if fact in lower_resp]
+        coverage = len(matches) / len(self.reference_facts) if self.reference_facts else 0.0
+        hallucination_score = 1.0 - coverage
+        return HallucinationResult(
+            prompt=prompt,
+            response=response,
+            score={"hallucination": hallucination_score},
+        )

--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from llmqa.hallucination import HallucinationEvaluator
+
+
+def test_hallucination_score_no_hallucination():
+    evaluator = HallucinationEvaluator([
+        "la ipa es amarga",
+        "la stout es oscura",
+    ])
+    result = evaluator.evaluate(
+        "Describe dos tipos de cerveza",
+        "La IPA es amarga y la stout es oscura."
+    )
+    assert result.score["hallucination"] == 0.0
+
+
+def test_hallucination_score_with_hallucination():
+    evaluator = HallucinationEvaluator(["hecho conocido"])
+    result = evaluator.evaluate(
+        "Pregunta",
+        "Respuesta inventada que no coincide"
+    )
+    assert result.score["hallucination"] == 1.0


### PR DESCRIPTION
## Summary
- add `llmqa.hallucination` module with simple scoring heuristics
- expose new classes in package init
- document hallucination evaluation in README
- add tests for the hallucination evaluator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b947fdd008331bf2e91c315775166