### PR TITLE
Add consistency evaluator with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ llm-qa-evaluator/
   - Gestión de prompts con utilidades simples en Python.
   - Automatización de la validación de outputs mediante `pytest`.
   - Evaluación de alucinaciones mediante el módulo `llmqa.hallucination`.
+  - Verificación de consistencia usando `llmqa.consistency`.
 - **Casos de Estudio de Ingeniería de Prompts**
   - Documentación de iteraciones y hallazgos.
 - **Documentación Profesional**

--- a/llmqa/__init__.py
+++ b/llmqa/__init__.py
@@ -1,9 +1,11 @@
 from .evaluator import LLMEvaluator, PromptResult
 from .hallucination import HallucinationEvaluator, HallucinationResult
+from .consistency import ConsistencyEvaluator
 
 __all__ = [
     "LLMEvaluator",
     "PromptResult",
     "HallucinationEvaluator",
     "HallucinationResult",
+    "ConsistencyEvaluator",
 ]

--- a/llmqa/consistency.py
+++ b/llmqa/consistency.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Callable
+
+
+class ConsistencyEvaluator:
+    """Simple evaluator to check if a model is consistent when answering the same prompt multiple times."""
+
+    def __init__(self, model_call: Callable[[str], str], runs: int = 3):
+        self.model_call = model_call
+        self.runs = runs
+
+    def check_consistency(self, prompt: str) -> bool:
+        responses = [self.model_call(prompt) for _ in range(self.runs)]
+        first = responses[0]
+        return all(r == first for r in responses)

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from llmqa.consistency import ConsistencyEvaluator
+
+
+def deterministic_model(prompt: str) -> str:
+    return "respuesta fija"
+
+
+def test_consistency_true():
+    evaluator = ConsistencyEvaluator(deterministic_model, runs=3)
+    assert evaluator.check_consistency("pregunta")
+
+
+def test_consistency_false():
+    counter = {"n": 0}
+
+    def varying_model(prompt: str) -> str:
+        counter["n"] += 1
+        return f"{prompt}-{counter['n']}"
+
+    evaluator = ConsistencyEvaluator(varying_model, runs=3)
+    assert not evaluator.check_consistency("pregunta")


### PR DESCRIPTION
## Summary
- implement `ConsistencyEvaluator` for repeated prompt checking
- expose the new evaluator in the package
- document consistency checks in the README
- add unit tests for deterministic and varying model behavior

## Testing
- `python -m py_compile llmqa/*.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b95eabac88331a489c6e950054286