### PR TITLE
Add comparator for multiple LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ llm-qa-evaluator/
   - Automatización de la validación de outputs mediante `pytest`.
   - Evaluación de alucinaciones mediante el módulo `llmqa.hallucination`.
   - Verificación de consistencia usando `llmqa.consistency`.
+  - Comparación de modelos usando `llmqa.comparator`.
 - **Casos de Estudio de Ingeniería de Prompts**
   - Documentación de iteraciones y hallazgos.
 - **Documentación Profesional**

--- a/llmqa/__init__.py
+++ b/llmqa/__init__.py
@@ -1,6 +1,7 @@
 from .evaluator import LLMEvaluator, PromptResult
 from .hallucination import HallucinationEvaluator, HallucinationResult
 from .consistency import ConsistencyEvaluator
+from .comparator import LLMComparator, ModelOutput
 
 __all__ = [
     "LLMEvaluator",
@@ -8,4 +9,6 @@ __all__ = [
     "HallucinationEvaluator",
     "HallucinationResult",
     "ConsistencyEvaluator",
+    "LLMComparator",
+    "ModelOutput",
 ]

--- a/llmqa/comparator.py
+++ b/llmqa/comparator.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+
+@dataclass
+class ModelOutput:
+    """Simple container for a model name and its generated response."""
+
+    model_name: str
+    response: str
+
+
+class LLMComparator:
+    """Utility to compare multiple LLMs on the same prompt."""
+
+    def __init__(self, model_calls: Dict[str, Callable[[str], str]]):
+        """`model_calls` is a mapping of model name to callable."""
+        self.model_calls = model_calls
+
+    def compare(self, prompt: str) -> List[ModelOutput]:
+        """Return the response from each model for the given prompt."""
+        outputs = []
+        for name, call in self.model_calls.items():
+            outputs.append(ModelOutput(model_name=name, response=call(prompt)))
+        return outputs

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from llmqa.comparator import LLMComparator
+
+
+def model_a(prompt: str) -> str:
+    return f"A:{prompt}"
+
+
+def model_b(prompt: str) -> str:
+    return f"B:{prompt}"
+
+
+def model_c(prompt: str) -> str:
+    return f"C:{prompt}"
+
+
+def test_compare_outputs():
+    comparator = LLMComparator({
+        "gpt": model_a,
+        "claude": model_b,
+        "cohere": model_c,
+    })
+    results = comparator.compare("hola")
+    assert [r.response for r in results] == ["A:hola", "B:hola", "C:hola"]


### PR DESCRIPTION
## Summary
- implement `LLMComparator` to compare outputs from several models
- expose new class in the package
- document comparison tool in README
- test comparison logic with three fake models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b973d91b883319f50bd5e45f52469